### PR TITLE
changed ios algo used for timestretching to higher qual

### DIFF
--- a/ios/versioned-react-native/ABI26_0_0/Expo/Core/Api/AV/ABI26_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI26_0_0/Expo/Core/Api/AV/ABI26_0_0EXAVPlayerData.m
@@ -155,7 +155,7 @@ NSString *const ABI26_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -289,7 +289,7 @@ NSString *const ABI26_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
     
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI27_0_0/Expo/Core/Api/AV/ABI27_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI27_0_0/Expo/Core/Api/AV/ABI27_0_0EXAVPlayerData.m
@@ -155,7 +155,7 @@ NSString *const ABI27_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -289,7 +289,7 @@ NSString *const ABI27_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
     
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI28_0_0/Expo/Core/Api/AV/ABI28_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI28_0_0/Expo/Core/Api/AV/ABI28_0_0EXAVPlayerData.m
@@ -155,7 +155,7 @@ NSString *const ABI28_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -289,7 +289,7 @@ NSString *const ABI28_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI29_0_0/Expo/Core/Api/AV/ABI29_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI29_0_0/Expo/Core/Api/AV/ABI29_0_0EXAVPlayerData.m
@@ -155,7 +155,7 @@ NSString *const ABI29_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -289,7 +289,7 @@ NSString *const ABI29_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/Api/AV/ABI30_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/Api/AV/ABI30_0_0EXAVPlayerData.m
@@ -155,7 +155,7 @@ NSString *const ABI30_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -289,7 +289,7 @@ NSString *const ABI30_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI31_0_0/Expo/Core/Api/AV/ABI31_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI31_0_0/Expo/Core/Api/AV/ABI31_0_0EXAVPlayerData.m
@@ -158,7 +158,7 @@ NSString *const ABI31_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -292,7 +292,7 @@ NSString *const ABI31_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/ios/versioned-react-native/ABI32_0_0/Expo/Core/Api/AV/ABI32_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI32_0_0/Expo/Core/Api/AV/ABI32_0_0EXAVPlayerData.m
@@ -158,7 +158,7 @@ NSString *const ABI32_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -292,7 +292,7 @@ NSString *const ABI32_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -156,7 +156,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
           strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
 
           if (strongSelfInner.shouldCorrectPitch) {
-            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+            strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
           } else {
             strongSelfInner.player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
           }
@@ -290,7 +290,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 
     // Apply idempotent parameters.
     if (_shouldCorrectPitch) {
-      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmLowQualityZeroLatency;
+      _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmSpectral;
     } else {
       _player.currentItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithmVarispeed;
     }


### PR DESCRIPTION
# Why

Issue #3197 
 
# How

Quick fix for making local builds by changing the fixed algorithm to a high quality / more processor intensive one.

# Test Plan

Tested by running https://snack.expo.io/@jiveworld/cmViZW in the Expo app built with this on an iPhone 7 plus (iOS 12.1.3)